### PR TITLE
Fixed bug where serving on Windows, getting from Unix results in broken tarballs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Fixed bug where serving on Windows and getting from Unix resulted in broken tarballs
+
 ## 1.0.0
 
 - Initial version.

--- a/bin/pub_cache_server.dart
+++ b/bin/pub_cache_server.dart
@@ -10,26 +10,41 @@ import "package:pub_cache_server/pub_cache_server.dart";
 
 void main(List<String> args) async {
   final parser = ArgParser();
-  parser.addOption("cache",
-      abbr: "c",
-      help:
-          "The path to your Pub cache. Can be omitted if the PUB_CACHE environment variable is set");
-  parser.addOption("address",
-      abbr: "a",
-      defaultsTo: "127.0.0.1",
-      help: "The address to host the server on");
-  parser.addOption("port",
-      abbr: "p", defaultsTo: "8000", help: "The port to host the server on");
-  parser.addOption("domain",
-      abbr: "d",
-      defaultsTo: "pub.dev",
-      help: "The domain of the online Pub server you use");
-  parser.addFlag("help",
-      abbr: "h", negatable: false, help: "Show this help message");
+  parser.addOption(
+    "cache",
+    abbr: "c",
+    help: "The path to your Pub cache. "
+        "Can be omitted if the PUB_CACHE environment variable is set",
+  );
+  parser.addOption(
+    "address",
+    abbr: "a",
+    defaultsTo: "127.0.0.1",
+    help: "The address to host the server on",
+  );
+  parser.addOption(
+    "port",
+    abbr: "p",
+    defaultsTo: "8000",
+    help: "The port to host the server on",
+  );
+  parser.addOption(
+    "domain",
+    abbr: "d",
+    defaultsTo: "pub.dev",
+    help: "The domain of the online Pub server you use",
+  );
+  parser.addFlag(
+    "help",
+    abbr: "h",
+    negatable: false,
+    help: "Show this help message",
+  );
   final results = parser.parse(args);
   if (results.flag("help")) {
     print(
-        "\nUsage: pub_cache_server [--cache <cache-dir>] [--port <port>] [--address <address>]\n");
+      "\nUsage: pub_cache_server [--cache <cache-dir>] [--port <port>] [--address <address>]\n",
+    );
     print(parser.usage);
     exit(0);
   }
@@ -42,7 +57,8 @@ void main(List<String> args) async {
   final resolvedCache = results.option("cache") ?? cacheEnv;
   if (resolvedCache == null) {
     print(
-        "Error: If you omit --cache, you must define the PUB_CACHE environment variable");
+      "Error: If you omit --cache, you must define the PUB_CACHE environment variable",
+    );
     exit(2);
   }
   Constants.init(

--- a/lib/src/tar.dart
+++ b/lib/src/tar.dart
@@ -11,7 +11,8 @@ extension on File {
 Stream<TarEntry> getTarEntries(Directory source, String outputName) async* {
   await for (final entry in source.list(recursive: true)) {
     if (entry is! File) continue;
-    final name = p.relative(entry.path, from: source.path);
+    final name =
+        p.posix.relative(entry.path, from: source.path).replaceAll(r"\", "/");
     if (name.startsWith(".")) continue;
     if (name == outputName) continue;
     final stat = entry.statSync();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pub_cache_server
 description: A Pub server that serves from your device's Pub cache. Can be used for serving packages to an otherwise-offline device
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/Levi-Lesches/pub_cache_server
 
 environment:


### PR DESCRIPTION
Fixed by naively replacing all `\` with `/`